### PR TITLE
fix fopen problem with dir in get_response func

### DIFF
--- a/fshared.c
+++ b/fshared.c
@@ -228,7 +228,10 @@ get_response(int conn)
         free(recv_payload) ;
         return ;
     }
-
+    if(!S_ISREG(filestat.st_mode))
+    {
+        fprintf(stderr, "It is not regular file %s!\n", recv_payload) ;
+    }
     sh.is_error = 0 ;
     sh.payload_size = filestat.st_size ;
 
@@ -381,6 +384,7 @@ go_thread(void * arg)
     return NULL;
 }
 
+#ifndef TEST
 int
 main(int argc, char * argv[])
 {
@@ -428,3 +432,4 @@ main(int argc, char * argv[])
 
     return 0 ;
 }
+#endif


### PR DESCRIPTION
#8 
get_response 함수에서 fopen을 사용하는데,
fopen을 readonly로 열면 file path가 Directory이여도 오류가 발생하지 않더라구요.
그렇게 되면 fread에서는 오류가 나고, 원하는 결과를 얻지 못해요. 

그래서 그전에 lstat을 사용하니까 이때 regular file인지 아닌지 확인하고 넘어가는게 좋을 것 같습니다.